### PR TITLE
Changes WMS layer to the Retina layer on MapProxy.

### DIFF
--- a/app/baseMap.js
+++ b/app/baseMap.js
@@ -40,7 +40,7 @@ export var baseLayerOptions = {
 function getBaseLayer() {
   return L.tileLayer.wms('https://gs.mapventure.org/geoserver/wms', {
     ...baseLayerOptions,
-    layers: ['alaska_osm'],
+    layers: ['alaska_osm_retina'],
   })
 }
 


### PR DESCRIPTION
This PR is to remove the dependency of the old MapProxy layer alaska_osm that is being removed. We instead want to make use of the alaska_osm_retina layer that has retina tiles.

To use this branch, be sure to use NVM to switch to v10.24.0 before installing and running.

nvm install 10.24.0
npm install
npm run dev

Service runs on http://localhost:8080

Ensure the map base layers are showing up for this change to be merge worthy.