### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -16,7 +16,7 @@
 
   <title>Living off the Land: Environmental impacts to access in Interior Alaska</title>
 
-  <script async defer data-website-id="2cc0e2a7-2f41-4500-bce9-77eab64d5913" src="https://umami.snap.uaf.edu/umami.js" data-do-not-track="true" data-domains="snap.uaf.edu">
+  <script async defer data-website-id="2cc0e2a7-2f41-4500-bce9-77eab64d5913" src="https://umami.snap.uaf.edu/script.js" data-do-not-track="true" data-domains="snap.uaf.edu">
   </script>
 
   <style>


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `index.ejs` to:

```
 <script async defer data-website-id="2cc0e2a7-2f41-4500-bce9-77eab64d5913" src="http://localhost:9999/script.js" data-do-not-track="true">
 </script>
```

Note that the `data-domains` attribute has been removed in the code above, for testing.

Then run this webapp locally and verify that your traffic shows up here: http://localhost:9999/websites/2cc0e2a7-2f41-4500-bce9-77eab64d5913