### PR TITLE
Replace gs.mapventure.org with gs.earthmaps.io throughout code

### DIFF
--- a/app/baseMap.js
+++ b/app/baseMap.js
@@ -38,7 +38,7 @@ export var baseLayerOptions = {
 }
 
 function getBaseLayer() {
-  return L.tileLayer.wms('https://gs.mapventure.org/geoserver/wms', {
+  return L.tileLayer.wms('https://gs.earthmaps.io/geoserver/wms', {
     ...baseLayerOptions,
     layers: ['alaska_osm'],
   })

--- a/app/exampleMapScroller.js
+++ b/app/exampleMapScroller.js
@@ -10,7 +10,7 @@ L.geoJSON(snowIceObs).addTo(map)
 var temps1970s = L.tileLayer
   .wms(
     // eslint-disable-line
-    'https://gs.mapventure.org/geoserver/wms',
+    'https://gs.earthmaps.io/geoserver/wms',
     {
       ...baseLayerOptions,
       layers: ['nasa_above:wintertemp_1970s_tcc'],
@@ -23,7 +23,7 @@ var temps1970sLayerEl = document.getElementsByClassName('temps-1970s')[0]
 var temps2010s = L.tileLayer
   .wms(
     // eslint-disable-line
-    'https://gs.mapventure.org/geoserver/wms',
+    'https://gs.earthmaps.io/geoserver/wms',
     {
       ...baseLayerOptions,
       layers: ['nasa_above:wintertemp_2010s_tcc'],

--- a/app/historicalFiresMapScroller.js
+++ b/app/historicalFiresMapScroller.js
@@ -9,7 +9,7 @@ layers[3].addTo(firesMap)
 getCommunitiesLayer().addTo(firesMap)
 
 L.tileLayer
-  .wms('https://gs.mapventure.org/geoserver/wms', {
+  .wms('https://gs.earthmaps.io/geoserver/wms', {
     ...baseLayerOptions,
     layers: ['historical_fire_perimiters'],
     className: 'animate-layer map-layer-invisible fire_history_70s_2010s',

--- a/app/permafrostMapScroller.js
+++ b/app/permafrostMapScroller.js
@@ -15,7 +15,7 @@ var permafrostMapLayers = [
   'July_permafrost_2m_2010s_tcc',
 ].map(layerName => {
   L.tileLayer
-    .wms('https://gs.mapventure.org/geoserver/wms', {
+    .wms('https://gs.earthmaps.io/geoserver/wms', {
       ...baseLayerOptions,
       layers: ['nasa_above:' + layerName],
       className: 'animate-layer map-layer-invisible ' + layerName,

--- a/app/snowdayFractionMapScroller.js
+++ b/app/snowdayFractionMapScroller.js
@@ -15,7 +15,7 @@ var snowdayFractionMapLayers = [
   'Oct_snowdayfraction_2010s_tcc_reprojected',
 ].map(layerName => {
   L.tileLayer
-    .wms('https://gs.mapventure.org/geoserver/wms', {
+    .wms('https://gs.earthmaps.io/geoserver/wms', {
       ...baseLayerOptions,
       layers: ['nasa_above:' + layerName],
       className: 'animate-layer map-layer-invisible ' + layerName,

--- a/app/winterTempsMapScroller.js
+++ b/app/winterTempsMapScroller.js
@@ -17,7 +17,7 @@ tempsFrozenSeasonMapLayers = [
   'wintertemp_2010s_tcc',
 ].map(layerName => {
   L.tileLayer
-    .wms('https://gs.mapventure.org/geoserver/wms', {
+    .wms('https://gs.earthmaps.io/geoserver/wms', {
       ...baseLayerOptions,
       layers: ['nasa_above:' + layerName],
       className: 'animate-layer map-layer-invisible ' + layerName,


### PR DESCRIPTION
This PR simply replaces `gs.mapventure.org` with `gs.earthmaps.io` throughout the code. I've already gone ahead and deployed the webapp with this change since the built webapp requires some manual intervention to deploy correctly anyway. So, to test, just look at the production webapp.